### PR TITLE
PHP 8: add official support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,24 @@ on: [push]
 jobs:
     build-test:
         runs-on: ubuntu-latest
-        
+
+        strategy:
+          matrix:
+            php-versions: ['7.4', '8.0']
+        name: PHP ${{ matrix.php-versions }} Test
+
         steps:
-            - uses: actions/checkout@v2
-            - uses: php-actions/composer@v1
-            - name: PHPUnit Tests
-              uses: php-actions/phpunit@v9
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
               with:
-                  configuration: ./phpunit.xml
+                  php-version: ${{ matrix.php-versions }}
+                  tools: composer:v2, phpunit:v9
+
+            - name: Install Dependencies
+              run: composer install
+
+            - name: PHPUnit Tests
+              run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0 ",
         "ext-json": "*",
         "ext-curl": "*",
         "psr/http-message": "^1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <testsuites>
     <testsuite name="main">
-      <directory phpVersion="7.3.0" phpVersionOperator="&gt;=" suffix="Test.php">tests</directory>
+      <directory suffix="Test.php">tests</directory>
       <exclude>tests/FronteggApiTest.php</exclude>
     </testsuite>
   </testsuites>


### PR DESCRIPTION
This adds PHP 8.0 as a supported version, and updates tests to run on PHP 7 and PHP 8.