### PR TITLE
Add config option for "authentication base url"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ $config = [
     'clientId' => 'YOUR_CLIENT_ID',
     'clientSecret' => 'YOUR_SECRET_API_KEY',
     'apiBaseUrl' => 'https://api.frontegg.com/',
+    'authenticationBaseUrl' => 'https://api.frontegg.com/',
     'apiUrls' => [
         'authentication' => '/auth/vendor',
         'audits' => '/audits',
@@ -89,6 +90,7 @@ $frontegg->init();
 | **clientSecret**  | string | None | API Key. Required |
 | **contextResolver**   | callable | None | Callback to provide context info. Required |
 | apiBaseUrl        | string | https://api.frontegg.com | Base API URL |
+| authenticationBaseUrl | string | https://api.frontegg.com | Base URL used for authentication |
 | apiUrls           | array | [] | List of URLs of the API services |
 | disableCors       | bool | false | Disabling CORS headers for Middleware Proxy |
 | httpClientHandler | special interface* | Curl client** | Custom HTTP client |

--- a/src/Frontegg/Authenticator/Authenticator.php
+++ b/src/Frontegg/Authenticator/Authenticator.php
@@ -90,7 +90,7 @@ class Authenticator
      */
     public function authenticate(): void
     {
-        $url = $this->fronteggConfig->getServiceUrl(
+        $url = $this->fronteggConfig->getAuthenticationUrl(
             Config::AUTHENTICATION_SERVICE
         );
         $body = json_encode(

--- a/src/Frontegg/Frontegg.php
+++ b/src/Frontegg/Frontegg.php
@@ -102,6 +102,7 @@ class Frontegg
                 'clientId' => getenv(static::CLIENT_ID_ENV_NAME),
                 'clientSecret' => getenv(static::CLIENT_SECRET_ENV_NAME),
                 'apiBaseUrl' => static::DEFAULT_API_BASE_URL,
+                'authenticationBaseUrl' => static::DEFAULT_API_BASE_URL,
                 'apiUrls' => [],
                 'apiVersion' => static::DEFAULT_API_VERSION,
                 'httpClientHandler' => null,
@@ -138,7 +139,8 @@ class Frontegg
             $config['apiBaseUrl'],
             $config['apiUrls'],
             $config['disableCors'],
-            $config['contextResolver']
+            $config['contextResolver'],
+            $config['authenticationBaseUrl']
         );
         $this->client = $config['httpClientHandler'] ??
             new FronteggCurlHttpClient();

--- a/tests/Authenticator/AuthenticatorTest.php
+++ b/tests/Authenticator/AuthenticatorTest.php
@@ -3,7 +3,9 @@
 namespace Frontegg\Tests\Authenticator;
 
 use DateTime;
+use Frontegg\HttpClient\FronteggCurlHttpClient;
 use Frontegg\Tests\Helper\AuthenticatorTestCaseHelper;
+use Prophecy\Argument;
 
 class AuthenticatorTest extends AuthenticatorTestCaseHelper
 {
@@ -167,5 +169,33 @@ class AuthenticatorTest extends AuthenticatorTestCaseHelper
             'Unauthorized',
             $authenticator->getApiError()->getError()
         );
+    }
+
+    public function testAuthenticatorCallsAuthUrl()
+    {
+        $authBaseUrl = 'http://authentication';
+
+        $client = $this->prophesize(FronteggCurlHttpClient::class);
+        $client->send(
+            Argument::containingString($authBaseUrl),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any()
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($this->createAuthHttpApiRawResponse());
+
+        $authenticator = $this->createFronteggAuthenticator(
+            $client->reveal(),
+            'clientTestID',
+            'apiTestSecretKey',
+            'http://test',
+            [],
+            true,
+            null,
+            $authBaseUrl
+        );
+        $authenticator->authenticate();
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -23,7 +23,8 @@ class ConfigTest extends TestCase
             false,
             function (RequestInterface $request) {
                 return [];
-            }
+            },
+            'https://auth/'
         );
 
         // Assert
@@ -52,14 +53,16 @@ class ConfigTest extends TestCase
             false,
             function (RequestInterface $request) {
                 return [];
-            }
+            },
+            'https://auth/'
         );
 
         // Assert
         $this->assertEquals('https://api.frontegg.com', $config->getBaseUrl());
+        $this->assertEquals('https://auth', $config->getAuthenticationBaseUrl());
         $this->assertEquals(
-            'https://api.frontegg.com/test/auth',
-            $config->getServiceUrl(Config::AUTHENTICATION_SERVICE)
+            'https://auth/test/auth',
+            $config->getAuthenticationUrl(Config::AUTHENTICATION_SERVICE)
         );
         $this->assertEquals(
             'https://api.frontegg.com/audits',
@@ -96,18 +99,28 @@ class ConfigTest extends TestCase
             false,
             function (RequestInterface $request) {
                 return [];
-            }
+            },
+            'https://auth/'
         );
 
         // Assert
         $this->assertEquals(
-            $config->getBaseUrl() . Config::AUTHENTICATION_SERVICE_DEFAULT_URL,
-            $config->getServiceUrl(Config::AUTHENTICATION_SERVICE)
+            $config->getAuthenticationBaseUrl() . Config::AUTHENTICATION_SERVICE_DEFAULT_URL,
+            $config->getAuthenticationUrl(Config::AUTHENTICATION_SERVICE)
+        );
+        $this->assertEquals(
+            $config->getBaseUrl() . Config::EVENTS_SERVICE_DEFAULT_URL,
+            $config->getServiceUrl(Config::EVENTS_SERVICE)
         );
         $this->expectException(InvalidUrlConfigException::class);
         $this->assertNotEquals(
             'should not be in the config',
             $config->getServiceUrl('randomUrl')
+        );
+        $this->expectException(InvalidUrlConfigException::class);
+        $this->assertNotEquals(
+            'should not be in the config',
+            $config->getAuthenticationUrl('randomUrl')
         );
     }
 }

--- a/tests/FronteggTest.php
+++ b/tests/FronteggTest.php
@@ -49,6 +49,14 @@ class FronteggTest extends AuthenticatorTestCaseHelper
             'apiTestSecretKey',
             $frontegg->getConfig()->getClientSecret()
         );
+        $this->assertEquals(
+            Frontegg::DEFAULT_API_BASE_URL,
+            $frontegg->getConfig()->getBaseUrl()
+        );
+        $this->assertEquals(
+            Frontegg::DEFAULT_API_BASE_URL,
+            $frontegg->getConfig()->getAuthenticationBaseUrl()
+        );
         $this->assertInstanceOf(
             FronteggHttpClientInterface::class,
             $frontegg->getClient()

--- a/tests/Helper/AuthenticatorTestCaseHelper.php
+++ b/tests/Helper/AuthenticatorTestCaseHelper.php
@@ -28,7 +28,8 @@ abstract class AuthenticatorTestCaseHelper extends TestCase
         string $baseUrl = 'http://test',
         array $urls = [],
         bool $disbaleCors = true,
-        ?callable $contextResolver = null
+        ?callable $contextResolver = null,
+        string $authenticationBaseUrl = 'http://auth'
     ): Authenticator {
         $contextResolver = $contextResolver ?? function () {
             return [];
@@ -39,7 +40,8 @@ abstract class AuthenticatorTestCaseHelper extends TestCase
             $baseUrl,
             $urls,
             $disbaleCors,
-            $contextResolver
+            $contextResolver,
+            $authenticationBaseUrl
         );
 
         return new Authenticator($fronteggConfig, $client);


### PR DESCRIPTION
Background
--

While getting hybrid mode working, we discovered that API requests require an auth token from Frontegg Cloud to send API requests to the hybrid instance. In other words, the base url to authenticate will be different than the base url for the rest of the API endpoints.

As a simple solution, I added `authenticationBaseUrl` to the Frontegg config which defaults to the typical API base url. This means that the normal base url can be changed appropriately when in a Frontegg Hybrid Mode environment without affecting the url used to authenticate.